### PR TITLE
change homebrew script url

### DIFF
--- a/tasks/script.yml
+++ b/tasks/script.yml
@@ -2,6 +2,6 @@
 # By Script
 - name: Ensure that homebrew is installed with the script method
   shell: >
-         ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
+         ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
          creates=/usr/local/Cellar
 


### PR DESCRIPTION
Bugfix for the following error:

```
TASK: [osxc.homebrew | Ensure that homebrew is installed with the script method] *** 
<localhost> REMOTE_MODULE command ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)" creates=/usr/local/Cellar #USE_SHELL
<localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1411662392.19-129252326056225 && chmod a+rx $HOME/.ansible/tmp/ansible-tmp-1411662392.19-129252326056225 && echo $HOME/.ansible/tmp/ansible-tmp-1411662392.19-129252326056225']
<localhost> PUT /var/folders/d4/h0hxk4f13k7bv7801yz3k7k80000zk/T/tmpyLS9VA TO /Users/username/.ansible/tmp/ansible-tmp-1411662392.19-129252326056225/command
<localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /Users/username/.ansible/tmp/ansible-tmp-1411662392.19-129252326056225/command; rm -rf /Users/username/.ansible/tmp/ansible-tmp-1411662392.19-129252326056225/ >/dev/null 2>&1']
changed: [localhost] => {"changed": true, "cmd": "ruby -e \"$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)\"", "delta": "0:00:01.417363", "end": "2014-09-25 18:26:33.671838", "rc": 0, "start": "2014-09-25 18:26:32.254475", "stderr": "", "stdout": "Whoops, the Homebrew installer has moved! Please instead run:\n\nruby -e \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)\"\n\nAlso, please ask wherever you got this link from to update it to the above.\nThanks!"}
```
