### PR TITLE
cask env export

### DIFF
--- a/tasks/cask.yml
+++ b/tasks/cask.yml
@@ -18,3 +18,7 @@
               state=present
               owner={{ item }}
   with_items: affected_users
+    
+- name: export new cask opts
+  environment:
+    HOMEBREW_CASK_OPTS: '--appdir=/Applications'


### PR DESCRIPTION
cask setting to export before playbook run

Just writing the HOMEBREW_CASK_OPTS to common_env does not load them, so they are not activated until a new terminal is opened. This defeats the purpose of the setting.
