### PR TITLE
Update brew cask executable name

### DIFF
--- a/tasks/cask.yml
+++ b/tasks/cask.yml
@@ -1,6 +1,6 @@
 ---
 - name: assert cask presence
-  stat: path={{ install_dir }}/bin/brew-cask.rb
+  stat: path={{ install_dir }}/bin/brew-cask
   register: cask_installed
 
 - name: tap the cask repository


### PR DESCRIPTION
brew-cask.rb was renamed to brew-cask in release 0.51.0 in December 16th 2014 (https://github.com/caskroom/homebrew-cask/pull/8089).
This causes brew cask be installed on every run of osxc playbooks.
